### PR TITLE
Initialize Vue frontend and ASP.NET Core backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node
+node_modules/
+*.log
+
+# Vite build output
+frontend/dist/
+
+# VS/ .NET
+bin/
+obj/
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# ProyectoVueBase
+# Proyecto Base
+
+Este repositorio contiene una base inicial para un proyecto compuesto por:
+
+- **frontend**: aplicación Vue 3 configurada con TypeScript, Vite y Tailwind CSS.
+- **backend**: proyecto de ASP.NET Core 8 con una Minimal API.
+- **scripts**: carpeta para almacenar scripts de base de datos de Microsoft SQL Server.
+
+## Estructura
+
+```
+.
+├── backend
+│   ├── BackendApi.csproj
+│   └── Program.cs
+├── frontend
+│   ├── index.html
+│   ├── package.json
+│   ├── src
+│   │   ├── App.vue
+│   │   ├── assets
+│   │   │   └── main.css
+│   │   └── main.ts
+│   ├── tailwind.config.js
+│   └── vite.config.ts
+├── scripts
+│   └── README.md
+└── README.md
+```
+
+## Requisitos
+
+- Node.js 18+
+- .NET 8 SDK
+
+## Comandos útiles
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Backend
+
+```bash
+cd backend
+dotnet restore
+dotnet run
+```
+
+Coloca tus scripts de base de datos en la carpeta `scripts`.

--- a/backend/BackendApi.csproj
+++ b/backend/BackendApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,13 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/", () => Results.Json(new
+{
+    Message = "Bienvenido a la Minimal API en ASP.NET Core",
+    Timestamp = DateTimeOffset.UtcNow
+}));
+
+app.MapGet("/health", () => Results.Ok(new { Status = "Healthy" }));
+
+app.Run();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend Vue 3</title>
+  </head>
+  <body class="bg-slate-100 text-slate-900">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.6",
+    "vitest": "^1.3.1"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const message = 'Bienvenido a tu proyecto Vue 3 con TypeScript y Tailwind CSS';
+</script>
+
+<template>
+  <main class="min-h-screen flex items-center justify-center">
+    <section class="max-w-xl rounded-2xl bg-white p-10 shadow-lg">
+      <h1 class="text-3xl font-bold text-sky-600">{{ message }}</h1>
+      <p class="mt-4 text-slate-600">
+        Este es un punto de partida ligero utilizando Vite. Empieza a desarrollar en
+        <code class="rounded bg-slate-100 px-2 py-1 text-sm text-slate-700">src/App.vue</code>.
+      </p>
+    </section>
+  </main>
+</template>
+
+<style scoped>
+code {
+  font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+}
+</style>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,8 @@
+import './assets/main.css';
+
+import { createApp } from 'vue';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.mount('#app');

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{vue,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts de base de datos
+
+Coloca aquí los scripts de Microsoft SQL Server (`.sql`) necesarios para el proyecto.


### PR DESCRIPTION
## Summary
- scaffold a Vue 3 + TypeScript frontend configured with Tailwind CSS and Vite
- add an ASP.NET Core 8 minimal API project structure
- document the repository layout and add a scripts directory for SQL Server assets

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dec8a636b48329b1a1822595bdab91