### PR TITLE
Disable HTTPS redirection for backend

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -11,7 +11,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();
 
 app.MapGet("/", () => Results.Json(new
     {

--- a/backend/Properties/launchSettings.json
+++ b/backend/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7180;http://localhost:5180",
+      "applicationUrl": "http://localhost:5180",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Summary
- comment out HTTPS redirection middleware so the API no longer forces HTTPS
- update the BackendApi launch profile to only use the HTTP URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded7075bc88329af7a69a84ba1f56e